### PR TITLE
rpm_sign: implement the necessary commands

### DIFF
--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -17,7 +17,7 @@ default)
 
 Options
 
---key         Name of the key to use
+--key         Name of the key to use (see rpm-sign --list-keys)
 --keyfile     Full path location of the keyfile, defaults to
               /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
@@ -40,10 +40,8 @@ Positional Arguments:
             logger.info('%s matching paths found' % len(paths))
             # FIXME: this should spit the actual verified command
             logger.info('will sign with the following commands:')
-            logger.info('gpg --armor --detach-sig --output Release.gpg Release')
-            logger.info('gpg --clearsign --output InRelease Release')
             logger.info('rpm-sign --key "%s" --detachsign Release --output Release.gpg' % self.key)
-            logger.info('rpm-sign --key "%s" --clearsign Release > InRelease' % self.key)
+            logger.info('rpm-sign --key "%s" --clearsign Release --output InRelease' % self.key)
         else:
             logger.warning('No paths found that matched')
 
@@ -55,5 +53,9 @@ Positional Arguments:
                 logger.info('[CHECKMODE] signed: %s' % new_gpg_path)
                 logger.info('[CHECKMODE] signed: %s' % new_in_path)
             else:
-                # XXX do actual signing here
-                pass
+                os.chdir(os.path.dirname(path))
+                detached = ['rpm-sign', '--key', self.key, '--detachsign', 'Release', '--output', 'Release.gpg']
+                clearsign = ['rpm-sign', '--key', self.key, '--clearsign', 'Release', '--output', 'InRelease']
+                logger.info('signing: %s' % path)
+                util.run(detached)
+                util.run(clearsign)

--- a/merfi/util.py
+++ b/merfi/util.py
@@ -134,7 +134,7 @@ blue_arrow = colorize.make('-->').blue
 
 def run_output(command, **kw):
     logger.info('Running command: %s' % ' '.join(command))
-    _run_output(command, **kw)
+    return _run_output(command, **kw)
 
 
 def _run_output(cmd, verbose=False, **kw):

--- a/merfi/util.py
+++ b/merfi/util.py
@@ -132,16 +132,28 @@ red_arrow = colorize.make('-->').red
 blue_arrow = colorize.make('-->').blue
 
 
-def run_check(command, **kw):
+def run_output(command, **kw):
     logger.info('Running command: %s' % ' '.join(command))
-    _run(command, stop_on_nonzero=True, **kw)
+    _run_output(command, **kw)
 
 
-def run(command, exit=False, **kw):
+def _run_output(cmd, verbose=False, **kw):
+    process = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kw
+    )
+    stdout = [line.strip('\n') for line in process.stdout.readlines()]
+    stderr = [line.strip('\n') for line in process.stderr.readlines()]
+    if verbose:
+        for line in stdout:
+            logger.debug(line)
+        for line in stderr:
+            logger.warning(stderr)
+    return stdout, stderr, process.wait()
+
+
+def run(command, **kw):
     logger.info('Running command: %s' % ' '.join(command))
     _run(command, stop_on_nonzero=True, **kw)
-    if exit:
-        raise SystemExit(0)
 
 
 def _run(cmd, **kw):

--- a/merfi/util.py
+++ b/merfi/util.py
@@ -148,7 +148,7 @@ def _run_output(cmd, verbose=False, **kw):
             logger.debug(line)
         for line in stderr:
             logger.warning(stderr)
-    return stdout, stderr, process.wait()
+    return '\n'.join(stdout), '\n'.join(stderr), process.wait()
 
 
 def run(command, **kw):


### PR DESCRIPTION
Pass the necessary commands to util.run.

In the help text, provide users with a command to look up available keys.