### PR TITLE
test RpmSign class and improve --key arg handling

### DIFF
--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -47,6 +47,8 @@ Positional Arguments:
         logger.info('Starting path collection, looking for files to sign')
         self.keyfile = self.parser.get('--keyfile', 'Release.gpg')
         self.key = self.parser.get('--key')
+        if not self.key:
+            raise RuntimeError('specify a --key for signing')
         paths = FileCollector(self.path)
 
         if paths:

--- a/merfi/tests/backends/base.py
+++ b/merfi/tests/backends/base.py
@@ -1,6 +1,5 @@
 import pytest
 import merfi
-from mock import call
 
 # inherit this class when testing a backend
 class BaseBackendTest(object):
@@ -8,7 +7,6 @@ class BaseBackendTest(object):
     def test_sign_no_files(self, m_util):
         self.backend.path = ''
         self.backend.sign()
-        assert not m_util.run.called
 
     def test_sign_two_files(self, m_util, repotree):
         # Use our tempdir fixture.
@@ -18,12 +16,3 @@ class BaseBackendTest(object):
         # the cmdline?)
         merfi.config['check'] = False
         self.backend.sign()
-        # Our repotree fixture has two "Release" files.
-        # Each one gets detached-signed and clearsign'd.
-        calls = [
-            call(self.detached),
-            call(self.clearsign),
-            call(self.detached),
-            call(self.clearsign),
-        ]
-        m_util.run.assert_has_calls(calls)

--- a/merfi/tests/backends/base.py
+++ b/merfi/tests/backends/base.py
@@ -4,8 +4,8 @@ import merfi
 # inherit this class when testing a backend
 class BaseBackendTest(object):
 
-    def test_sign_no_files(self, m_util):
-        self.backend.path = ''
+    def test_sign_no_files(self, m_util, tmpdir):
+        self.backend.path = str(tmpdir)
         self.backend.sign()
 
     def test_sign_two_files(self, m_util, repotree):

--- a/merfi/tests/backends/test_gpg.py
+++ b/merfi/tests/backends/test_gpg.py
@@ -12,8 +12,8 @@ class TestGpg(BaseBackendTest):
     clearsign = ['gpg', '--batch', '--yes', '--clearsign', '--output', 'InRelease', 'Release']
 
     @patch("merfi.backends.gpg.util")
-    def test_sign_no_files(self, m_util):
-        super(TestGpg, self).test_sign_no_files(m_util)
+    def test_sign_no_files(self, m_util, tmpdir):
+        super(TestGpg, self).test_sign_no_files(m_util, tmpdir)
         assert not m_util.run.called
 
     @patch("merfi.backends.gpg.util")

--- a/merfi/tests/backends/test_gpg.py
+++ b/merfi/tests/backends/test_gpg.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import call, patch
 import pytest
 from merfi.backends import gpg
 from merfi.tests.backends.base import BaseBackendTest
@@ -13,8 +13,18 @@ class TestGpg(BaseBackendTest):
 
     @patch("merfi.backends.gpg.util")
     def test_sign_no_files(self, m_util):
-        return super(TestGpg, self).test_sign_no_files(m_util)
+        super(TestGpg, self).test_sign_no_files(m_util)
+        assert not m_util.run.called
 
     @patch("merfi.backends.gpg.util")
     def test_sign_two_files(self, m_util, repotree):
-        return super(TestGpg, self).test_sign_two_files(m_util, repotree)
+        super(TestGpg, self).test_sign_two_files(m_util, repotree)
+        # Our repotree fixture has two "Release" files.
+        # Each one gets detached-signed and clearsign'd.
+        calls = [
+            call(self.detached),
+            call(self.clearsign),
+            call(self.detached),
+            call(self.clearsign),
+        ]
+        m_util.run.assert_has_calls(calls)

--- a/merfi/tests/backends/test_rpm_sign.py
+++ b/merfi/tests/backends/test_rpm_sign.py
@@ -1,0 +1,40 @@
+from mock import call, patch
+import pytest
+from merfi.backends import rpm_sign
+from merfi.tests.backends.base import BaseBackendTest
+from tambo import Transport
+
+class TestRpmSign(BaseBackendTest):
+
+    backend = rpm_sign.RpmSign([])
+    # fake command-line args
+    argv = ['merfi', '--key', 'mykey']
+    backend.parser = Transport(argv, options=backend.options)
+    backend.parser.parse_args()
+
+    # args to merfi.backends.rpm_sign.util's run()
+    detached = ['rpm-sign', '--key', 'mykey', '--detachsign', 'Release', '--output', 'Release.gpg']
+    # args to merfi.backends.rpm_sign.util's run_output()
+    clearsign = ['rpm-sign', '--key', 'mykey', '--clearsign', 'Release']
+
+    @patch('merfi.backends.rpm_sign.util')
+    def test_sign_no_files(self, m_util, tmpdir):
+        super(TestRpmSign, self).test_sign_no_files(m_util, tmpdir)
+        assert not m_util.run.called
+        assert not m_util.run_output.called
+
+    @patch('merfi.backends.rpm_sign.util')
+    def test_sign_two_files(self, m_util, repotree):
+        # Fake the return values for inline-signing
+        m_util.run_output.return_value = ('--PGP SIGNED MESSAGE--', None, None)
+        super(TestRpmSign, self).test_sign_two_files(m_util, repotree)
+        detached_calls = [
+            call(self.detached),
+            call(self.detached),
+        ]
+        clearsign_calls = [
+            call(self.clearsign),
+            call(self.clearsign),
+        ]
+        m_util.run.assert_has_calls(detached_calls)
+        m_util.run_output.assert_has_calls(clearsign_calls)


### PR DESCRIPTION
The first commit in this PR lays the groundwork for being able to extend BaseBackendTest to test the RpmSign class by refactoring the specific assertions out of the parent class.

The second commit tidies up an issue I encountered while testing with some spurious "Release" files in my tree.

The third commit improves the `--key` argument handling for rpm-sign.

The last commit adds tests for RpmSign.

(The `--keyfile` argument is still not yet functional here, but this PR sets us up to fix that.)