### PR TITLE
fix Gpg backend tests

### DIFF
--- a/merfi/backends/gpg.py
+++ b/merfi/backends/gpg.py
@@ -41,7 +41,7 @@ Positional Arguments:
             logger.warning('No paths found that matched')
 
         for path in paths:
-            if merfi.config['check']:
+            if merfi.config.get('check'):
                 new_gpg_path = path.split('Release')[0]+'Release.gpg'
                 new_in_path = path.split('Release')[0]+'InRelease'
                 logger.info('[CHECKMODE] signing: %s' % path)

--- a/merfi/tests/backends/test_gpg.py
+++ b/merfi/tests/backends/test_gpg.py
@@ -1,9 +1,8 @@
 from mock import call, patch
 import pytest
 from merfi.backends import gpg
-from merfi.tests.backends.base import BaseBackendTest
 
-class TestGpg(BaseBackendTest):
+class TestGpg(object):
 
     backend = gpg.Gpg([])
 
@@ -13,12 +12,14 @@ class TestGpg(BaseBackendTest):
 
     @patch("merfi.backends.gpg.util")
     def test_sign_no_files(self, m_util, tmpdir):
-        super(TestGpg, self).test_sign_no_files(m_util, tmpdir)
+        self.backend.path = str(tmpdir)
+        self.backend.sign()
         assert not m_util.run.called
 
     @patch("merfi.backends.gpg.util")
     def test_sign_two_files(self, m_util, repotree):
-        super(TestGpg, self).test_sign_two_files(m_util, repotree)
+        self.backend.path = repotree
+        self.backend.sign()
         # Our repotree fixture has two "Release" files.
         # Each one gets detached-signed and clearsign'd.
         calls = [


### PR DESCRIPTION
The first commit in this PR removes the requirement for the "check" flag (similar to the change that was made for the RpmSign backend in
30698ebf23be3421c743e6720b9205060226ae0b

The second commit removes GpgTest's reliance on `BaseBackendTest`, since that was removed in 94ea9c258d254b371b3ad832cd039c1785f6ca65.