### PR TITLE
Iso: better default --output, and test make_iso()

### DIFF
--- a/merfi/iso.py
+++ b/merfi/iso.py
@@ -14,14 +14,14 @@ source directory has proper read permissions).
 
 Default behavior will perform these actions on a source directory::
 
-    genisoimage -r -o isofile {source directory}
-    sha256sum isofile > isofile.SHA256SUM
+    genisoimage -r -o sourcedir-dvd.iso {source directory}
+    sha256sum sourcedir-dvd.iso > sourcedir-dvd.iso.SHA256SUM
 
 %s
 
 Options:
 
--o, --output      Custom filename output (defaults to 'isofile').
+-o, --output      Custom filename output (defaults to '<sourcedir>-dvd.iso').
 
 Positional Arguments:
 
@@ -38,8 +38,8 @@ Positional Arguments:
         parser = Transport(argv, options=options)
         parser.catch_help = self.help()
         parser.parse_args()
-        self.output = parser.get('--output', 'isofile')
         self.source = util.infer_path(parser.unknown_commands)
+        self.output = parser.get('--output', self.source + '-dvd.iso')
         self.check_dependency()
         self.make_iso()
         self.make_sha256sum()

--- a/merfi/iso.py
+++ b/merfi/iso.py
@@ -30,9 +30,12 @@ Positional Arguments:
     executable = 'genisoimage'
     name = 'iso'
 
-    def parse_args(self):
+    def parse_args(self, argv=None):
+        """ pass argv during testing """
+        if argv is None:
+            argv = self.argv
         options = [['--output', '-o']]
-        parser = Transport(self.argv, options=options)
+        parser = Transport(argv, options=options)
         parser.catch_help = self.help()
         parser.parse_args()
         self.output = parser.get('--output', 'isofile')

--- a/merfi/tests/test_iso.py
+++ b/merfi/tests/test_iso.py
@@ -6,7 +6,8 @@ from merfi.util import which
 
 class TestIso(object):
 
-    def create_test_iso(self, output_dir):
+    def create_fake_iso(self, output_dir):
+        """ Create a fake ISO file, without genisoimage """
         iso = Iso([])
         f = output_dir.join('test.iso')
         f.write('ISOCONTENTS')
@@ -15,7 +16,7 @@ class TestIso(object):
         return iso
 
     def test_sha256sum_contents(self, tmpdir):
-        iso = self.create_test_iso(tmpdir)
+        iso = self.create_fake_iso(tmpdir)
         with open(iso.output_checksum, 'r') as chsumf:
             assert chsumf.read() == "d8d322f6864229f8c9ef1b0845dd9e182c563c508fec30618fdb9b57c70a0147  test.iso\n"
 
@@ -25,6 +26,6 @@ class TestIso(object):
     # would run `sha256sum -c` on it.
     @pytest.mark.skipif(which('sha256sum') is None, reason='sha256sum is not installed')
     def test_sha256sum_command(self, tmpdir):
-        iso = self.create_test_iso(tmpdir)
+        iso = self.create_fake_iso(tmpdir)
         os.chdir(os.path.dirname(iso.output_checksum))
         assert subprocess.call(['sha256sum', '-c', iso.output_checksum]) == 0

--- a/merfi/tests/test_iso.py
+++ b/merfi/tests/test_iso.py
@@ -15,6 +15,20 @@ class TestIso(object):
         iso.make_sha256sum()
         return iso
 
+    def create_real_iso(self, output_dir):
+        """ Create a "real" ISO file, using make_iso() (ie genisoimage) """
+        # simple contents
+        compose_dir = output_dir.mkdir('my-test-contents')
+        f = compose_dir.join('contents.txt')
+        f.write('This text file will be on our ISO')
+
+        iso = Iso([])
+        argv = ['merfi', str(output_dir.join('my-test-contents'))]
+        iso.parse_args(argv)
+        iso.make_iso()
+        iso.make_sha256sum()
+        return iso
+
     def test_sha256sum_contents(self, tmpdir):
         iso = self.create_fake_iso(tmpdir)
         with open(iso.output_checksum, 'r') as chsumf:
@@ -29,3 +43,8 @@ class TestIso(object):
         iso = self.create_fake_iso(tmpdir)
         os.chdir(os.path.dirname(iso.output_checksum))
         assert subprocess.call(['sha256sum', '-c', iso.output_checksum]) == 0
+
+    @pytest.mark.skipif(which('genisoimage') is None, reason='genisoimage is not installed')
+    def test_make_iso(self, tmpdir):
+        iso = self.create_real_iso(tmpdir)
+        assert os.path.isfile(str(tmpdir.join('my-test-contents-dvd.iso')))


### PR DESCRIPTION
The first commit adds an `argv` argument Iso's `parse_args()`, to make it easier to inject fake values during testing.

The second commit changes the ISO backend to use a better default output filename. (https://github.com/alfredodeza/merfi/issues/15)

The third commit renames one of the test functions to "create_fake_iso()" to more clearly communicate what it does.

The fourth commit adds tests for `make_iso()`.