### PR TITLE
RpmSign: add --nat argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ repository::
 This feature is designed for Ceph's ISO installer (ice-setup), because it
 expects the GPG public key to be present in this location.
 
+If you are running the ``rpm-sign`` command  on a computer that is behind a
+NAT, you must pass the ``--nat`` argument, like so::
+
+    $ merfi rpm-sign --nat --key "mykey"
+
 gpg
 ---
 GPG support is similar to ``rpm-sign`` in that merfi will crawl a path

--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -22,6 +22,7 @@ Options
 --keyfile     Full path location of the public keyfile, for example
               /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
               or /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+--nat         A NAT is between this system and the signing server.
 
 Positional Arguments:
 
@@ -30,7 +31,7 @@ Positional Arguments:
     """
     executable = 'rpm-sign'
     name = 'rpm-sign'
-    options = ['--key', '--keyfile']
+    options = ['--key', '--keyfile', '--nat']
 
     def clear_sign(self, path, command):
         """
@@ -81,6 +82,9 @@ Positional Arguments:
                 os.chdir(os.path.dirname(path))
                 detached = ['rpm-sign', '--key', self.key, '--detachsign', 'Release', '--output', 'Release.gpg']
                 clearsign = ['rpm-sign', '--key', self.key, '--clearsign', 'Release']
+                if self.parser.has('--nat'):
+                    detached.insert( 1, '--nat')
+                    clearsign.insert( 1, '--nat')
                 logger.info('signing: %s' % path)
                 self.detached(detached)
                 self.clear_sign(path, clearsign)

--- a/merfi/tests/backends/test_rpm_sign.py
+++ b/merfi/tests/backends/test_rpm_sign.py
@@ -94,3 +94,21 @@ class TestRpmSignKeyfile(RpmSign):
 
         release_key = os.path.join(repotree, 'release.asc')
         assert cmp(str(keyfile), release_key)
+
+class TestRpmSignNat(RpmSign):
+
+    def test_keyfile_path(self, repotree, rpmsign):
+        backend = rpmsign
+        # fake command-line args
+        argv = ['merfi', '--key', 'mykey', '--nat']
+        backend.parser = Transport(argv, options=backend.options)
+        backend.parser.parse_args()
+        backend.path = repotree
+        backend.sign()
+
+        clearsign = ['rpm-sign', '--nat', '--key', 'mykey', '--clearsign', 'Release']
+
+        # first call, second argument (the command to run)
+        assert backend.clear_sign.calls[0][0][1] == clearsign
+        # second call, second argument (the command to run)
+        assert backend.clear_sign.calls[1][0][1] == clearsign


### PR DESCRIPTION
When running behind a NAT, the `rpm-sign` command requires a `--nat` flag.

Fixes #18