### PR TITLE
allow nested repos to be crawled

### DIFF
--- a/merfi/backends/gpg.py
+++ b/merfi/backends/gpg.py
@@ -31,10 +31,7 @@ Positional Arguments:
     def sign(self):
         logger.info('Starting path collection, looking for files to sign')
         repos = RepoCollector(self.path)
-        paths = []
-        for repo in repos:
-            repo_paths = RepoCollector.debian_release_files(repo)
-            paths.extend(repo_paths)
+        paths = repos.debian_release_files
 
         if paths:
             logger.info('%s matching paths found' % len(paths))

--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -57,10 +57,7 @@ Positional Arguments:
             raise RuntimeError('specify a --key for signing')
         logger.info('Starting path collection, looking for files to sign')
         repos = RepoCollector(self.path)
-        paths = []
-        for repo in repos:
-            repo_paths = RepoCollector.debian_release_files(repo)
-            paths.extend(repo_paths)
+        paths = repos.debian_release_files
 
         if paths:
             logger.info('%s matching paths found' % len(paths))

--- a/merfi/collector.py
+++ b/merfi/collector.py
@@ -32,15 +32,12 @@ class RepoCollector(list):
 
         # Local is faster
         walk = os.walk
-        join = os.path.join
         path = self.path
 
         for root, dirs, files in walk(path):
-            for item in dirs:
-                absolute_path = join(root, item)
-                if not self.is_debian_repo(item):
-                    continue
-                self.append(absolute_path)
+            if self.is_debian_repo(root):
+                self.append(root)
+                continue
 
     def is_debian_repo(self, directory):
         """ Is 'directory' a Debian repository ? """
@@ -53,8 +50,8 @@ class RepoCollector(list):
             return False
         return True
 
-    @staticmethod
-    def debian_release_files(repo):
+    @property
+    def debian_release_files(self):
         """ Find all the "Release" files to be signed within a Debian repo """
         result = []
 
@@ -63,12 +60,10 @@ class RepoCollector(list):
         join = os.path.join
         isfile = os.path.isfile
 
-        dists = join(repo, 'dists')
-
-        # Examine all immediate subdirectories in "dists":
-        root, dirs, files = next(walk(dists))
-        for dist in dirs:
-            release_file = join(root, dist, 'Release')
-            if isfile(release_file):
-                result.append(release_file)
+        for repo_path in self:
+            for root, dirs, files in walk(repo_path):
+                for dist in dirs:
+                    release_file = join(root, dist, 'Release')
+                    if isfile(release_file):
+                        result.append(release_file)
         return result

--- a/merfi/tests/conftest.py
+++ b/merfi/tests/conftest.py
@@ -25,3 +25,25 @@ def repotree(request, tmpdir):
         release_file.close()
 
     return top_dir
+
+
+@pytest.fixture(scope="function")
+def nested_repotree(request, tmpdir):
+    # Create a basic skeleton repository with "Release" files to sign.
+    directory = str(tmpdir)
+    os.makedirs(os.path.join(directory, 'nested'))
+    top_dir = os.path.join(directory, 'nested')
+    # Top directories:
+    os.mkdir(os.path.join(top_dir, 'db'))
+    os.mkdir(os.path.join(top_dir, 'dists'))
+    os.mkdir(os.path.join(top_dir, 'pool'))
+    # Distro "Release" files:
+    for distro in ['precise', 'trusty']:
+        distro_dir = os.path.join(top_dir, 'dists', distro)
+        os.mkdir(distro_dir)
+        release_file = open(os.path.join(distro_dir, 'Release'), 'w')
+        release_file.write('some Release metadata for %s' % distro)
+        release_file.close()
+
+    return top_dir
+

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -1,5 +1,5 @@
 from merfi.collector import RepoCollector
-from os.path import join
+from os.path import join, dirname
 
 
 class TestRepoCollector(object):
@@ -27,3 +27,13 @@ class TestRepoCollector(object):
             join(repotree, 'dists', 'precise', 'Release'),
         ]
         assert set(paths) == set(expected)
+
+    def test_debian_nested_release_files(self, repotree):
+        path = dirname(repotree)
+        paths = RepoCollector(path)
+        release_files = paths.debian_release_files
+        expected = [
+            join(repotree, 'dists', 'trusty', 'Release'),
+            join(repotree, 'dists', 'precise', 'Release'),
+        ]
+        assert set(release_files) == set(expected)

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -20,20 +20,22 @@ class TestRepoCollector(object):
         assert self.paths._abspath('directory').startswith('/')
 
     def test_debian_release_files(self, repotree):
-        paths = RepoCollector.debian_release_files(repotree)
+        paths = RepoCollector(repotree)
+        release_files = paths.debian_release_files
         # The root of the repotree fixture is itself a repository.
         expected = [
             join(repotree, 'dists', 'trusty', 'Release'),
             join(repotree, 'dists', 'precise', 'Release'),
         ]
-        assert set(paths) == set(expected)
+        assert set(release_files) == set(expected)
 
-    def test_debian_nested_release_files(self, repotree):
-        path = dirname(repotree)
+    def test_debian_nested_release_files(self, nested_repotree):
+        # go one level up
+        path = dirname(nested_repotree)
         paths = RepoCollector(path)
         release_files = paths.debian_release_files
         expected = [
-            join(repotree, 'dists', 'trusty', 'Release'),
-            join(repotree, 'dists', 'precise', 'Release'),
+            join(nested_repotree, 'dists', 'trusty', 'Release'),
+            join(nested_repotree, 'dists', 'precise', 'Release'),
         ]
         assert set(release_files) == set(expected)


### PR DESCRIPTION
Makes the `@staticmethod` go away by re-using the paths in the same class, allows to work with nested repos this way, simplifying the recursive behavior.