### PR TITLE
tests: rename repotree fixture for debian

### DIFF
--- a/merfi/tests/backends/test_gpg.py
+++ b/merfi/tests/backends/test_gpg.py
@@ -17,10 +17,10 @@ class TestGpg(object):
         assert not m_util.run.called
 
     @patch("merfi.backends.gpg.util")
-    def test_sign_two_files(self, m_util, repotree):
-        self.backend.path = repotree
+    def test_sign_two_files(self, m_util, deb_repotree):
+        self.backend.path = deb_repotree
         self.backend.sign()
-        # Our repotree fixture has two "Release" files.
+        # Our deb_repotree fixture has two "Release" files.
         # Each one gets detached-signed and clearsign'd.
         calls = [
             call(self.detached),

--- a/merfi/tests/backends/test_rpm_sign.py
+++ b/merfi/tests/backends/test_rpm_sign.py
@@ -46,33 +46,33 @@ class TestRpmSign(RpmSign):
         assert self.backend.detached.calls == []
         assert self.backend.clear_sign.calls == []
 
-    def test_sign_two_files_detached_and_clearsign(self, repotree):
-        self.sign(repotree)
+    def test_sign_two_files_detached_and_clearsign(self, deb_repotree):
+        self.sign(deb_repotree)
         assert len(self.backend.detached.calls) == 2
         assert len(self.backend.clear_sign.calls) == 2
 
-    def test_sign_two_files_path(self, repotree):
-        self.sign(repotree)
+    def test_sign_two_files_path(self, deb_repotree):
+        self.sign(deb_repotree)
         assert self.backend.detached.calls[0][0][0] == self.detached
         assert self.backend.detached.calls[1][0][0] == self.detached
 
-    def test_sign_two_files_command(self, repotree):
-        self.sign(repotree)
+    def test_sign_two_files_command(self, deb_repotree):
+        self.sign(deb_repotree)
         assert self.backend.detached.calls[0][0][0] == self.detached
         assert self.backend.detached.calls[1][0][0] == self.detached
 
 
 class TestRpmClearSign(RpmSign):
 
-    def test_sign_two_files_command(self, repotree):
-        self.sign(repotree)
+    def test_sign_two_files_command(self, deb_repotree):
+        self.sign(deb_repotree)
         # first call, second argument (the command to run)
         assert self.backend.clear_sign.calls[0][0][1] == self.clearsign
         # second call, second argument (the command to run)
         assert self.backend.clear_sign.calls[1][0][1] == self.clearsign
 
-    def test_sign_two_files_path(self, repotree):
-        self.sign(repotree)
+    def test_sign_two_files_path(self, deb_repotree):
+        self.sign(deb_repotree)
         first_path = self.backend.clear_sign.calls[0][0][0]
         second_path = self.backend.clear_sign.calls[1][0][0]
         assert first_path.endswith('/Release')
@@ -80,7 +80,7 @@ class TestRpmClearSign(RpmSign):
 
 class TestRpmSignKeyfile(RpmSign):
 
-    def test_keyfile_path(self, repotree, rpmsign, tmpdir):
+    def test_keyfile_path(self, deb_repotree, rpmsign, tmpdir):
         backend = rpmsign
         # fake keyfile
         keyfile = tmpdir.join('RPM-GPG-KEY-testing')
@@ -89,21 +89,21 @@ class TestRpmSignKeyfile(RpmSign):
         argv = ['merfi', '--key', 'mykey', '--keyfile', str(keyfile)]
         backend.parser = Transport(argv, options=backend.options)
         backend.parser.parse_args()
-        backend.path = repotree
+        backend.path = deb_repotree
         backend.sign()
 
-        release_key = os.path.join(repotree, 'release.asc')
+        release_key = os.path.join(deb_repotree, 'release.asc')
         assert cmp(str(keyfile), release_key)
 
 class TestRpmSignNat(RpmSign):
 
-    def test_keyfile_path(self, repotree, rpmsign):
+    def test_keyfile_path(self, deb_repotree, rpmsign):
         backend = rpmsign
         # fake command-line args
         argv = ['merfi', '--key', 'mykey', '--nat']
         backend.parser = Transport(argv, options=backend.options)
         backend.parser.parse_args()
-        backend.path = repotree
+        backend.path = deb_repotree
         backend.sign()
 
         clearsign = ['rpm-sign', '--nat', '--key', 'mykey', '--clearsign', 'Release']

--- a/merfi/tests/conftest.py
+++ b/merfi/tests/conftest.py
@@ -9,7 +9,7 @@ import shutil
 #     signed.
 # See https://github.com/alfredodeza/merfi/issues/6
 @pytest.fixture(scope="function")
-def repotree(request, tmpdir):
+def deb_repotree(request, tmpdir):
     # Create a basic skeleton repository with "Release" files to sign.
     top_dir = str(tmpdir)
     # Top directories:
@@ -28,7 +28,7 @@ def repotree(request, tmpdir):
 
 
 @pytest.fixture(scope="function")
-def nested_repotree(request, tmpdir):
+def nested_deb_repotree(request, tmpdir):
     # Create a basic skeleton repository with "Release" files to sign.
     directory = str(tmpdir)
     os.makedirs(os.path.join(directory, 'nested'))

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -7,10 +7,10 @@ class TestRepoCollector(object):
     def setup(self):
         self.paths = RepoCollector(path='/', _eager=False)
 
-    def test_simple_tree(self, repotree):
-        paths = RepoCollector(path=repotree)
-        # The root of the repotree fixture is itself a repository.
-        expected = [ repotree ]
+    def test_simple_tree(self, deb_repotree):
+        paths = RepoCollector(path=deb_repotree)
+        # The root of the deb_repotree fixture is itself a repository.
+        expected = [ deb_repotree ]
         assert set(paths) == set(expected)
 
     def test_path_is_absolute(self):
@@ -19,23 +19,23 @@ class TestRepoCollector(object):
     def test_path_is_not_absolute(self):
         assert self.paths._abspath('directory').startswith('/')
 
-    def test_debian_release_files(self, repotree):
-        paths = RepoCollector(repotree)
+    def test_debian_release_files(self, deb_repotree):
+        paths = RepoCollector(deb_repotree)
         release_files = paths.debian_release_files
-        # The root of the repotree fixture is itself a repository.
+        # The root of the deb_repotree fixture is itself a repository.
         expected = [
-            join(repotree, 'dists', 'trusty', 'Release'),
-            join(repotree, 'dists', 'precise', 'Release'),
+            join(deb_repotree, 'dists', 'trusty', 'Release'),
+            join(deb_repotree, 'dists', 'precise', 'Release'),
         ]
         assert set(release_files) == set(expected)
 
-    def test_debian_nested_release_files(self, nested_repotree):
+    def test_debian_nested_release_files(self, nested_deb_repotree):
         # go one level up
-        path = dirname(nested_repotree)
+        path = dirname(nested_deb_repotree)
         paths = RepoCollector(path)
         release_files = paths.debian_release_files
         expected = [
-            join(nested_repotree, 'dists', 'trusty', 'Release'),
-            join(nested_repotree, 'dists', 'precise', 'Release'),
+            join(nested_deb_repotree, 'dists', 'trusty', 'Release'),
+            join(nested_deb_repotree, 'dists', 'precise', 'Release'),
         ]
         assert set(release_files) == set(expected)


### PR DESCRIPTION
... to make room for an eventual rpm repotree fixture