### PR TITLE
rpm-sign: basic .rpm file support

### DIFF
--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -57,10 +57,10 @@ Positional Arguments:
             raise RuntimeError('specify a --key for signing')
         logger.info('Starting path collection, looking for files to sign')
         repos = RepoCollector(self.path)
-        paths = repos.debian_release_files
+        deb_paths = repos.debian_release_files
 
-        if paths:
-            logger.info('%s matching paths found' % len(paths))
+        if deb_paths:
+            logger.info('%s matching paths found' % len(deb_paths))
             # FIXME: this should spit the actual verified command
             logger.info('will sign with the following commands:')
             logger.info('rpm-sign --key "%s" --detachsign Release --output Release.gpg' % self.key)
@@ -68,7 +68,7 @@ Positional Arguments:
         else:
             logger.warning('No paths found that matched')
 
-        for path in paths:
+        for path in deb_paths:
             if merfi.config.get('check'):
                 new_gpg_path = path.split('Release')[0]+'Release.gpg'
                 new_in_path = path.split('Release')[0]+'InRelease'

--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -60,13 +60,13 @@ Positional Arguments:
         deb_paths = repos.debian_release_files
 
         if deb_paths:
-            logger.info('%s matching paths found' % len(deb_paths))
+            logger.info('%d debian repositories found' % len(deb_paths))
             # FIXME: this should spit the actual verified command
             logger.info('will sign with the following commands:')
             logger.info('rpm-sign --key "%s" --detachsign Release --output Release.gpg' % self.key)
             logger.info('rpm-sign --key "%s" --clearsign Release --output InRelease' % self.key)
         else:
-            logger.warning('No paths found that matched')
+            logger.warning('No debian repositories found')
 
         for path in deb_paths:
             if merfi.config.get('check'):

--- a/merfi/collector.py
+++ b/merfi/collector.py
@@ -73,6 +73,24 @@ class RepoCollector(list):
         return result
 
     @property
+    def rpm_repomd_files(self):
+        """ Find all the "repomd.xml" files to be signed within a RPM repo """
+        result = []
+
+        # Local is faster
+        walk = os.walk
+        join = os.path.join
+        isfile = os.path.isfile
+
+        for repo_path in self:
+            for root, dirs, files in walk(repo_path):
+                for dist in dirs:
+                    repomd_file = join(root, 'repodata', 'repomd.xml')
+                    if isfile(repomd_file):
+                        result.append(repomd_file)
+        return result
+
+    @property
     def rpm_files(self):
         """ Find all the .rpm files to be signed """
         result = []

--- a/merfi/tests/conftest.py
+++ b/merfi/tests/conftest.py
@@ -47,3 +47,24 @@ def nested_deb_repotree(request, tmpdir):
 
     return top_dir
 
+@pytest.fixture(scope="function")
+def rpm_repotree(request, tmpdir):
+    """ Create a basic set of repositories with .rpm files to sign. """
+    top_dir = str(tmpdir)
+    # RPM files and repo metadata:
+    for distro in ['el6', 'el7']:
+        distro_dir = os.path.join(top_dir, distro)
+        os.mkdir(distro_dir)
+        # Dummy .rpm file:
+        rpm_filename = 'test.%s.rpm' % distro
+        rpm_file = open(os.path.join(distro_dir, rpm_filename), 'w')
+        rpm_file.write('some RPM content for %s' % distro)
+        rpm_file.close()
+        # Dummy Yum/DNF repository metadata:
+        os.mkdir(os.path.join(distro_dir, 'repodata'))
+        repomd_path = os.path.join(distro_dir, 'repodata', 'repomd.xml')
+        repomd_file = open(repomd_path, 'w')
+        repomd_file.write('<xml>some Yum/DNF data for %s</xml>' % distro)
+        repomd_file.close()
+
+    return top_dir

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -49,3 +49,13 @@ class TestRepoCollector(object):
             join(rpm_repotree, 'el7', 'test.el7.rpm'),
         ]
         assert set(rpm_files) == set(expected)
+
+    def test_repomd_files(self, rpm_repotree):
+        paths = RepoCollector(rpm_repotree)
+        repomd_files = paths.rpm_repomd_files
+        # The repotree fixture contains two repositories.
+        expected = [
+            join(rpm_repotree, 'el6', 'repodata', 'repomd.xml'),
+            join(rpm_repotree, 'el7', 'repodata', 'repomd.xml'),
+        ]
+        assert set(repomd_files) == set(expected)

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -39,3 +39,13 @@ class TestRepoCollector(object):
             join(nested_deb_repotree, 'dists', 'precise', 'Release'),
         ]
         assert set(release_files) == set(expected)
+
+    def test_rpm_files(self, rpm_repotree):
+        paths = RepoCollector(rpm_repotree)
+        rpm_files = paths.rpm_files
+        # The repotree fixture contains two repositories, one package in each.
+        expected = [
+            join(rpm_repotree, 'el6', 'test.el6.rpm'),
+            join(rpm_repotree, 'el7', 'test.el7.rpm'),
+        ]
+        assert set(rpm_files) == set(expected)


### PR DESCRIPTION
This PR adds support for discovering `.rpm` files and Yum's `repomd.xml` files. It also updates the RpmSign backend to sign .rpm files that it discovers within RPM repositories.