### PR TITLE
Gpg: drop duplicate colon ":" in help

### DIFF
--- a/merfi/backends/gpg.py
+++ b/merfi/backends/gpg.py
@@ -11,7 +11,7 @@ class Gpg(base.BaseBackend):
 Signs files with gpg. Crawls a given path looking for 'Release' files (by
 default)
 
-Default behavior will perform these actions on 'Release' files::
+Default behavior will perform these actions on 'Release' files:
 
     gpg --armor --detach-sig --output Release.gpg Release
     gpg --clearsign --output InRelease Release


### PR DESCRIPTION
This is not rST so we don't need this double colon.