### PR TITLE
collector: use DebRepo objects

### DIFF
--- a/merfi/backends/gpg.py
+++ b/merfi/backends/gpg.py
@@ -8,8 +8,7 @@ from merfi.backends import base
 class Gpg(base.BaseBackend):
     help_menu = 'gpg handler for signing files'
     _help = """
-Signs files with gpg. Crawls a given path looking for 'Release' files (by
-default)
+Signs files with gpg. Crawls a given path looking for Debian repos.
 
 Default behavior will perform these actions on 'Release' files:
 
@@ -22,7 +21,7 @@ Options:
 
 Positional Arguments:
 
-[path]        The path to crawl for signing release files. Defaults to current
+[path]        The path to crawl for signing repos. Defaults to current
               working directory
 """
     executable = 'gpg'

--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -11,8 +11,7 @@ from merfi.backends import base
 class RpmSign(base.BaseBackend):
     help_menu = 'rpm-sign handler for signing files'
     _help = """
-Signs files with rpm-sign. Crawls a given path looking for 'Release' files (by
-default)
+Signs files with rpm-sign. Crawls a given path looking for Debian repos.
 
 %s
 
@@ -26,7 +25,7 @@ Options
 
 Positional Arguments:
 
-[path]        The path to crawl for signing release files. Defaults to current
+[path]        The path to crawl for signing repos. Defaults to current
               working directory
     """
     executable = 'rpm-sign'
@@ -95,4 +94,4 @@ Positional Arguments:
                 else:
                     shutil.copyfile(
                         self.keyfile,
-                        os.path.join(repo, 'release.asc'))
+                        os.path.join(repo.path, 'release.asc'))

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -8,10 +8,9 @@ class TestRepoCollector(object):
         self.paths = RepoCollector(path='/', _eager=False)
 
     def test_simple_tree(self, deb_repotree):
-        paths = RepoCollector(path=deb_repotree)
+        repos = RepoCollector(path=deb_repotree)
         # The root of the deb_repotree fixture is itself a repository.
-        expected = [ deb_repotree ]
-        assert set(paths) == set(expected)
+        assert [r.path for r in repos] == [deb_repotree]
 
     def test_path_is_absolute(self):
         assert self.paths._abspath('/') == '/'


### PR DESCRIPTION
Prior to this change, RepoCollector stored a list of strs (paths).  The `.debian_release_files` property would simply walk the tree looking for "Release" files, and return them all, even if they were irrelevant for GPG signing.

With this change, RepoCollector stores a list of DebRepo objects instead of strs. The `.debian_release_files` property only returns the specific repository Release file(s) that should be GPG-signed for Apt.

Update the help text for the gpg and rpm-sign backends to clarify that we're seeking and signing repos now, not just any Release files.