### PR TITLE
backends: refactor to new sign_release() method

### DIFF
--- a/merfi/backends/gpg.py
+++ b/merfi/backends/gpg.py
@@ -42,16 +42,22 @@ Positional Arguments:
             logger.warning('No paths found that matched')
 
         for path in paths:
-            if merfi.config.get('check'):
-                new_gpg_path = path.split('Release')[0]+'Release.gpg'
-                new_in_path = path.split('Release')[0]+'InRelease'
-                logger.info('[CHECKMODE] signing: %s' % path)
-                logger.info('[CHECKMODE] signed: %s' % new_gpg_path)
-                logger.info('[CHECKMODE] signed: %s' % new_in_path)
-            else:
-                os.chdir(os.path.dirname(path))
-                detached = ['gpg', '--batch', '--yes', '--armor', '--detach-sig', '--output', 'Release.gpg', 'Release']
-                clearsign = ['gpg', '--batch', '--yes', '--clearsign', '--output', 'InRelease', 'Release']
-                logger.info('signing: %s' % path)
-                util.run(detached)
-                util.run(clearsign)
+            self.sign_release(path)
+
+    def sign_release(self, path):
+        """ Sign a "Release" file from a Debian repo.  """
+        if merfi.config.get('check'):
+            new_gpg_path = path.split('Release')[0]+'Release.gpg'
+            new_in_path = path.split('Release')[0]+'InRelease'
+            logger.info('[CHECKMODE] signing: %s' % path)
+            logger.info('[CHECKMODE] signed: %s' % new_gpg_path)
+            logger.info('[CHECKMODE] signed: %s' % new_in_path)
+        else:
+            os.chdir(os.path.dirname(path))
+            detached = ['gpg', '--batch', '--yes', '--armor', '--detach-sig',
+                        '--output', 'Release.gpg', 'Release']
+            clearsign = ['gpg', '--batch', '--yes', '--clearsign', '--output',
+                         'InRelease', 'Release']
+            logger.info('signing: %s' % path)
+            util.run(detached)
+            util.run(clearsign)

--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -68,22 +68,7 @@ Positional Arguments:
             logger.warning('No paths found that matched')
 
         for path in paths:
-            if merfi.config.get('check'):
-                new_gpg_path = path.split('Release')[0]+'Release.gpg'
-                new_in_path = path.split('Release')[0]+'InRelease'
-                logger.info('[CHECKMODE] signing: %s' % path)
-                logger.info('[CHECKMODE] signed: %s' % new_gpg_path)
-                logger.info('[CHECKMODE] signed: %s' % new_in_path)
-            else:
-                os.chdir(os.path.dirname(path))
-                detached = ['rpm-sign', '--key', self.key, '--detachsign', 'Release', '--output', 'Release.gpg']
-                clearsign = ['rpm-sign', '--key', self.key, '--clearsign', 'Release']
-                if self.parser.has('--nat'):
-                    detached.insert( 1, '--nat')
-                    clearsign.insert( 1, '--nat')
-                logger.info('signing: %s' % path)
-                self.detached(detached)
-                self.clear_sign(path, clearsign)
+            self.sign_release(path)
 
         if self.keyfile:
             logger.info('using keyfile "%s" as release.asc' % self.keyfile)
@@ -95,3 +80,24 @@ Positional Arguments:
                     shutil.copyfile(
                         self.keyfile,
                         os.path.join(repo.path, 'release.asc'))
+
+    def sign_release(self, path):
+        """ Sign a "Release" file from a Debian repo.  """
+        if merfi.config.get('check'):
+            new_gpg_path = path.split('Release')[0]+'Release.gpg'
+            new_in_path = path.split('Release')[0]+'InRelease'
+            logger.info('[CHECKMODE] signing: %s' % path)
+            logger.info('[CHECKMODE] signed: %s' % new_gpg_path)
+            logger.info('[CHECKMODE] signed: %s' % new_in_path)
+        else:
+            os.chdir(os.path.dirname(path))
+            detached = ['rpm-sign', '--key', self.key, '--detachsign',
+                        'Release', '--output', 'Release.gpg']
+            clearsign = ['rpm-sign', '--key', self.key, '--clearsign',
+                         'Release']
+            if self.parser.has('--nat'):
+                detached.insert(1, '--nat')
+                clearsign.insert(1, '--nat')
+            logger.info('signing: %s' % path)
+            self.detached(detached)
+            self.clear_sign(path, clearsign)


### PR DESCRIPTION
Rather than signing all Release files in the main `sign()` method, break out the Release-file-specific bits into a new smaller method, `sign_release()`.

The purpose of this change is to make room to sign other things here besides Release files.