### PR TITLE
tests: rename RepoCollector return variable

### DIFF
--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -5,7 +5,7 @@ from os.path import join, dirname
 class TestRepoCollector(object):
 
     def setup(self):
-        self.paths = RepoCollector(path='/', _eager=False)
+        self.repos = RepoCollector(path='/', _eager=False)
 
     def test_simple_tree(self, deb_repotree):
         repos = RepoCollector(path=deb_repotree)
@@ -13,14 +13,14 @@ class TestRepoCollector(object):
         assert [r.path for r in repos] == [deb_repotree]
 
     def test_path_is_absolute(self):
-        assert self.paths._abspath('/') == '/'
+        assert self.repos._abspath('/') == '/'
 
     def test_path_is_not_absolute(self):
-        assert self.paths._abspath('directory').startswith('/')
+        assert self.repos._abspath('directory').startswith('/')
 
     def test_debian_release_files(self, deb_repotree):
-        paths = RepoCollector(deb_repotree)
-        release_files = paths.debian_release_files
+        repos = RepoCollector(deb_repotree)
+        release_files = repos.debian_release_files
         # The root of the deb_repotree fixture is itself a repository.
         expected = [
             join(deb_repotree, 'dists', 'trusty', 'Release'),
@@ -31,8 +31,8 @@ class TestRepoCollector(object):
     def test_debian_nested_release_files(self, nested_deb_repotree):
         # go one level up
         path = dirname(nested_deb_repotree)
-        paths = RepoCollector(path)
-        release_files = paths.debian_release_files
+        repos = RepoCollector(path)
+        release_files = repos.debian_release_files
         expected = [
             join(path, 'jewel', 'dists', 'trusty', 'Release'),
             join(path, 'jewel', 'dists', 'xenial', 'Release'),


### PR DESCRIPTION
`RepoCollector` now returns a list of `DebRepos`, not `str`s (paths).  Rename the variable to better reflect this.