### PR TITLE
tests: simplify tree fixtures

### DIFF
--- a/merfi/tests/backends/test_rpm_sign.py
+++ b/merfi/tests/backends/test_rpm_sign.py
@@ -47,10 +47,11 @@ class TestRpmSign(RpmSign):
         assert self.backend.detached.calls == []
         assert self.backend.clear_sign.calls == []
 
-    def test_sign_two_files_detached_and_clearsign(self, deb_repotree):
+    def test_sign_four_files_detached_and_clearsign(self, deb_repotree):
+        # jewel and luminous, trusty and xenial
         self.sign(deb_repotree)
-        assert len(self.backend.detached.calls) == 2
-        assert len(self.backend.clear_sign.calls) == 2
+        assert len(self.backend.detached.calls) == 4
+        assert len(self.backend.clear_sign.calls) == 4
 
     def test_sign_two_files_path(self, deb_repotree):
         self.sign(deb_repotree)
@@ -87,7 +88,8 @@ class TestRpmSignKeyfile(RpmSign):
         keyfile = tmpdir.join('RPM-GPG-KEY-testing')
         keyfile.write('-----BEGIN PGP PUBLIC KEY BLOCK-----')
         # Copy deb repo fixture to tmpdir for writing
-        copytree(deb_repotree, str(tmpdir.join('repo')))
+        src = os.path.join(deb_repotree, 'jewel')
+        copytree(src, str(tmpdir.join('repo')))
         # fake command-line args
         argv = ['merfi', '--key', 'mykey', '--keyfile', str(keyfile)]
         backend.parser = Transport(argv, options=backend.options)

--- a/merfi/tests/conftest.py
+++ b/merfi/tests/conftest.py
@@ -7,5 +7,5 @@ FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 
 @pytest.fixture(scope="function")
 def deb_repotree(request):
-    """ Return a single Debian repository to sign. """
-    return os.path.join(FIXTURES_DIR, 'debrepos', 'jewel')
+    """ Return a directory of Debian repositories to sign. """
+    return os.path.join(FIXTURES_DIR, 'debrepos')

--- a/merfi/tests/conftest.py
+++ b/merfi/tests/conftest.py
@@ -9,9 +9,3 @@ FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
 def deb_repotree(request):
     """ Return a single Debian repository to sign. """
     return os.path.join(FIXTURES_DIR, 'debrepos', 'jewel')
-
-
-@pytest.fixture(scope="function")
-def nested_deb_repotree(request):
-    """ Return a single Debian repository to sign. """
-    return os.path.join(FIXTURES_DIR, 'debrepos', 'jewel')

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -1,5 +1,5 @@
 from merfi.collector import RepoCollector, DebRepo
-from os.path import join, dirname
+from os.path import join
 
 
 class TestRepoCollector(object):
@@ -8,9 +8,9 @@ class TestRepoCollector(object):
         self.repos = RepoCollector(path='/', _eager=False)
 
     def test_simple_tree(self, deb_repotree):
-        repos = RepoCollector(path=deb_repotree)
-        # The root of the deb_repotree fixture is itself a repository.
-        assert [r.path for r in repos] == [deb_repotree]
+        path = join(deb_repotree, 'jewel')
+        repos = RepoCollector(path)
+        assert [r.path for r in repos] == [path]
 
     def test_path_is_absolute(self):
         assert self.repos._abspath('/') == '/'
@@ -19,37 +19,35 @@ class TestRepoCollector(object):
         assert self.repos._abspath('directory').startswith('/')
 
     def test_debian_repo(self, deb_repotree):
-        repos = RepoCollector(deb_repotree)
-        # The root of the deb_repotree fixture is itself a repository.
-        assert repos == [DebRepo(deb_repotree)]
+        # Select the root of one repository in our fixture.
+        path = join(deb_repotree, 'jewel')
+        repos = RepoCollector(path)
+        assert repos == [DebRepo(path)]
 
     def test_debian_release_files(self, deb_repotree):
-        repos = RepoCollector(deb_repotree)
-        # The root of the deb_repotree fixture is itself a repository.
+        # Select the root of one repository in our fixture.
+        path = join(deb_repotree, 'jewel')
+        repos = RepoCollector(path)
         expected = [
-            join(deb_repotree, 'dists', 'trusty', 'Release'),
-            join(deb_repotree, 'dists', 'xenial', 'Release'),
+            join(path, 'dists', 'trusty', 'Release'),
+            join(path, 'dists', 'xenial', 'Release'),
         ]
         assert set(repos[0].releases) == set(expected)
 
     def test_nested_debian_repo(self, deb_repotree):
-        # go one level up
-        path = dirname(deb_repotree)
-        repos = RepoCollector(path)
-        # Verify that we found the two repo trees.
-        expected = [DebRepo(join(path, 'jewel')),
-                    DebRepo(join(path, 'luminous'))]
+        repos = RepoCollector(deb_repotree)
+        # Verify that we found the two repos.
+        expected = [DebRepo(join(deb_repotree, 'jewel')),
+                    DebRepo(join(deb_repotree, 'luminous'))]
         assert repos == expected
 
     def test_debian_nested_release_files(self, deb_repotree):
-        # go one level up
-        path = dirname(deb_repotree)
-        repos = RepoCollector(path)
+        repos = RepoCollector(deb_repotree)
         release_files = [rfile for repo in repos for rfile in repo.releases]
         expected = [
-            join(path, 'jewel', 'dists', 'trusty', 'Release'),
-            join(path, 'jewel', 'dists', 'xenial', 'Release'),
-            join(path, 'luminous', 'dists', 'trusty', 'Release'),
-            join(path, 'luminous', 'dists', 'xenial', 'Release'),
+            join(deb_repotree, 'jewel', 'dists', 'trusty', 'Release'),
+            join(deb_repotree, 'jewel', 'dists', 'xenial', 'Release'),
+            join(deb_repotree, 'luminous', 'dists', 'trusty', 'Release'),
+            join(deb_repotree, 'luminous', 'dists', 'xenial', 'Release'),
         ]
         assert set(release_files) == set(expected)

--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -32,18 +32,18 @@ class TestRepoCollector(object):
         ]
         assert set(repos[0].releases) == set(expected)
 
-    def test_nested_debian_repo(self, nested_deb_repotree):
+    def test_nested_debian_repo(self, deb_repotree):
         # go one level up
-        path = dirname(nested_deb_repotree)
+        path = dirname(deb_repotree)
         repos = RepoCollector(path)
         # Verify that we found the two repo trees.
         expected = [DebRepo(join(path, 'jewel')),
                     DebRepo(join(path, 'luminous'))]
         assert repos == expected
 
-    def test_debian_nested_release_files(self, nested_deb_repotree):
+    def test_debian_nested_release_files(self, deb_repotree):
         # go one level up
-        path = dirname(nested_deb_repotree)
+        path = dirname(deb_repotree)
         repos = RepoCollector(path)
         release_files = [rfile for repo in repos for rfile in repo.releases]
         expected = [


### PR DESCRIPTION
The `deb_repotree` fixture was going to the work of `os.path.join()` to select "jewel" every time, and then we had further code in the nested tests to undo that work (with `os.path.dirname()`).

Simplify this by returning the parent dir directly in the fixture, and picking "jewel" only for the tests that need it.