### PR TITLE
Gpg: remove "will sign with the following commands" log

### DIFF
--- a/merfi/backends/gpg.py
+++ b/merfi/backends/gpg.py
@@ -33,10 +33,6 @@ Positional Arguments:
 
         if repos:
             logger.info('%s repos found' % len(repos))
-            # FIXME: this should spit the actual verified command
-            logger.info('will sign with the following commands:')
-            logger.info('gpg --batch --yes --armor --detach-sig --output Release.gpg Release')
-            logger.info('gpg --batch --yes --clearsign --output InRelease Release')
         else:
             logger.warning('No paths found that matched')
 


### PR DESCRIPTION
Do not log a general message about what we will run. `util.run()` already logs the exact command that we run each time, so that is more accurate.

This will also no longer be accurate once we start signing RPMs and Yum repodata.