### PR TITLE
tests: compare nested repo test results using sets

### DIFF
--- a/merfi/tests/test_repocollector.py
+++ b/merfi/tests/test_repocollector.py
@@ -39,7 +39,7 @@ class TestRepoCollector(object):
         # Verify that we found the two repos.
         expected = [DebRepo(join(deb_repotree, 'jewel')),
                     DebRepo(join(deb_repotree, 'luminous'))]
-        assert repos == expected
+        assert set(repos) == set(expected)
 
     def test_debian_nested_release_files(self, deb_repotree):
         repos = RepoCollector(deb_repotree)


### PR DESCRIPTION
Python does not guarantee os.walk returns results in a particular order.  In some cases (discovered on RHEL 6 / py26 in Koji, exact repro steps unknown), test_nested_debian_repo could fail when repocollector is a list ordered in a way we didn't expect.

Compare the sets in the nested_debian_repo repocollector test, just like we do for the other repocollector tests.