### PR TITLE
RpmSign: format strings for merfi.logger

### DIFF
--- a/merfi/backends/rpm_sign.py
+++ b/merfi/backends/rpm_sign.py
@@ -41,13 +41,13 @@ Positional Arguments:
         out, err, code = util.run_output(command)
         if code != 0:
             for line in err.split('\n'):
-                logger.error('stderr: %s', line)
+                logger.error('stderr: %s' % line)
             for line in out.split('\n'):
-                logger.error('stdout: %s', line)
+                logger.error('stdout: %s' % line)
             raise RuntimeError('rpm-sign non-zero exit code %d', code)
         if out.strip() == '':
             for line in err.split('\n'):
-                logger.error('stderr: %s', line)
+                logger.error('stderr: %s' % line)
             logger.error('rpm-sign clearsign provided nothing on stdout')
             raise RuntimeError('no clearsign signature available')
         absolute_directory = os.path.dirname(os.path.abspath(path))


### PR DESCRIPTION
When rpm-sign failed and we entered the failure-checking code path, we
hit a TypeError for merfi.logger:

    File "merfi/backends/rpm_sign.py", line 85, in sign
      self.sign_release(path)
    File "merfi/backends/rpm_sign.py", line 115, in sign_release
      self.clear_sign(path, clearsign)
    File "merfi/backends/rpm_sign.py", line 44, in clear_sign
      logger.error('stderr: %s', line)
    TypeError: error() takes exactly 1 argument (2 given)

merfi's custom logger class expects a single "message" argument.
Format the error message strings before passing to the logger.