### PR TITLE
README: fix rST preformatting for gpg example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ gpg
 ---
 GPG support is similar to ``rpm-sign`` in that merfi will crawl a path
 (defaults to the current working directory) looking for Debian repositories,
-and sign the appropriate ``Release`` files:
+and sign the appropriate ``Release`` files::
 
     $ merfi gpg
     --> signing: /Users/alfredo/repos/debian/dists/trusty/Release


### PR DESCRIPTION
Prior to this change, the GPG example command and output was not preformatted in reStructuredText. Use the double-colon to tell Sphinx to preformat this.