### PR TITLE
tox.ini: Python 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =  py26, py27, py33
+envlist =  py26, py27, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.3 is old. Let's go with the latest that Travis CI supports.