### PR TITLE
backends: use absolute imports

### DIFF
--- a/merfi/backends/__init__.py
+++ b/merfi/backends/__init__.py
@@ -1,2 +1,4 @@
-import rpm_sign
-import gpg
+from __future__ import absolute_import
+
+import merfi.backends.rpm_sign
+import merfi.backends.gpg


### PR DESCRIPTION
Python 3 raises an error here:

```
ModuleNotFoundError: No module named 'rpm_sign'
```

Use absolute imports instead so the code works on Python 3.

Enable the `absolute_imports` behavior from `__future__` to make Python 2.6 and 2.7 behave the same as Python 3 in this regard.