### PR TITLE
logger: handle bytes log messages

### DIFF
--- a/merfi/logger.py
+++ b/merfi/logger.py
@@ -64,7 +64,10 @@ class LogMessage(object):
         return _level_colors.get(self.level_name, 'info')
 
     def line(self):
-        msg = self.message.rstrip('\n')
+        message = self.message
+        if isinstance(message, bytes):
+            message = message.decode('utf-8')
+        msg = message.rstrip('\n')
         return "%s %s\n" % (self.header(), msg)
 
     def write(self):


### PR DESCRIPTION
In Python 3, the output from Popen is bytes, not str. This leads to a crash later on in our logger, because rstrip() does not work on bytes.

Transparently handle bytes messages in our logger by decoding them to strings.