### PR TITLE
tox: execute pytest in all environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@ envlist =  py26, py27, py36
 [testenv]
 deps =
     pytest
+commands = py.test
+
 [testenv:py26]
 deps =
     argparse
     pytest
-
 commands = py.test


### PR DESCRIPTION
`tox` was not executing `pytest` in any environment except `py26`.