### PR TITLE
tests: import mock on py2 and py3

### DIFF
--- a/merfi/tests/backends/test_gpg.py
+++ b/merfi/tests/backends/test_gpg.py
@@ -1,4 +1,7 @@
-from mock import call, patch
+try:
+    from unittest.mock import call, patch
+except ImportError:  # PY2
+    from mock import call, patch
 import pytest
 from merfi.backends import gpg
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,12 @@ commands = py.test
 [testenv:py26]
 deps =
     argparse
+    mock
+    pytest
+commands = py.test
+
+[testenv:py27]
+deps =
+    mock
     pytest
 commands = py.test


### PR DESCRIPTION
`unittest.mock` is in the stdlib on Python 3.

On Python 2, we need `mock` from PyPI.